### PR TITLE
Set model for Repositories from the constructor.

### DIFF
--- a/app/Providers/RepositoriesServiceProvider.php
+++ b/app/Providers/RepositoriesServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Models\User;
 use Illuminate\Support\ServiceProvider;
 use App\Repositories\Contracts\UserRepository;
 use App\Repositories\EloquentUserRepository;
@@ -22,7 +23,9 @@ class RepositoriesServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(UserRepository::class, EloquentUserRepository::class);
+        $this->app->bind(UserRepository::class, function () {
+            return new EloquentUserRepository(new User());
+        });
     }
 
     /**

--- a/app/Repositories/AbstractEloquentRepository.php
+++ b/app/Repositories/AbstractEloquentRepository.php
@@ -33,31 +33,10 @@ abstract class AbstractEloquentRepository implements BaseRepository
     /**
      * Constructor
      */
-    public function __construct()
+    public function __construct(Model $model)
     {
-        $this->setModel();
+        $this->model = $model;
         $this->loggedInUser = $this->getLoggedInUser();
-    }
-
-    /**
-     * Instantiate Model
-     *
-     * @throws \Exception
-     */
-    public function setModel()
-    {
-        //check if the class exists
-        if (class_exists($this->modelName)) {
-            $this->model = new $this->modelName;
-
-            //check object is a instanceof Illuminate\Database\Eloquent\Model
-            if (!$this->model instanceof Model) {
-                throw new \Exception("{$this->modelName} must be an instance of Illuminate\Database\Eloquent\Model");
-            }
-
-        } else {
-            throw new \Exception('No model name defined');
-        }
     }
 
     /**

--- a/app/Repositories/EloquentUserRepository.php
+++ b/app/Repositories/EloquentUserRepository.php
@@ -10,13 +10,6 @@ use App\Events\UserEvents\UserCreatedEvent;
 
 class EloquentUserRepository extends AbstractEloquentRepository implements UserRepository
 {
-    /**
-     * Model name
-     *
-     * @var string
-     */
-    protected $modelName = User::class;
-
 
     /*
      * @inheritdoc

--- a/readme.md
+++ b/readme.md
@@ -238,8 +238,12 @@ class RepositoriesServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->bind(UserRepository::class, EloquentUserRepository::class);
-        $this->app->bind(MessageRepository::class, EloquentMessageRepository::class);
+        $this->app->bind(UserRepository::class, function () {
+            return new EloquentUserRepository(new User());
+        });
+        $this->app->bind(MessageRepository::class, function () {
+            return new EloquentMessageRepository(new Message());
+        });
     }
 
     /**

--- a/tests/Repositories/EloquentUserRepositoryTest.php
+++ b/tests/Repositories/EloquentUserRepositoryTest.php
@@ -20,7 +20,7 @@ class EloquentUserRepositoryTest extends \TestCase
     public function setup()
     {
         parent::setUp();
-        $this->eloquentUserRepository = new EloquentUserRepository();
+        $this->eloquentUserRepository = new EloquentUserRepository(new User());
     }
 
     public function testCreateUser()
@@ -72,7 +72,7 @@ class EloquentUserRepositoryTest extends \TestCase
         // when instantiate the repo, logged in as Admin user. So, that we can search any user
         $adminUser = factory(User::class)->make(['role' => User::ADMIN_ROLE]);
         Auth::shouldReceive('user')->andReturn($adminUser);
-        $eloquentUserRepository = new EloquentUserRepository();
+        $eloquentUserRepository = new EloquentUserRepository(new User());
 
         //get total users of this resource
         $totalUsers = User::all()->count();


### PR DESCRIPTION
This pull request is based on the issue [here](https://github.com/hasib32/rest-api-with-lumen/issues/22)

I've added a parameter in the repository constructor to be able to pass a child of the base model. 
I've run all tests before this commit and they all passed. Also, I've updated Readme guides. 
