### PR TITLE
Show how scopes are difened 

### DIFF
--- a/app/Http/Controllers/AccessTokenController.php
+++ b/app/Http/Controllers/AccessTokenController.php
@@ -44,14 +44,9 @@ class AccessTokenController extends Controller
             $user = $this->userRepository->findOneBy(['email' => $inputs['username']]);
         }
 
-        if ($user instanceof User) {
-            // user with basic role can only request for basic scope
-            if ($user->role === User::BASIC_ROLE) {
-                $inputs['scope'] = 'basic';
-            }
-        } else {
-            // client_credentials grant can only request for basic scope
-            $inputs['scope'] = 'basic';
+        //Set default scope with full access
+        if (!isset($inputs['scope']) || empty($inputs['scope'])) {
+            $inputs['scope'] = "*";
         }
 
         $tokenRequest = $request->create('/oauth/token', 'post', $inputs);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -57,4 +57,12 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     protected $hidden = [
         'password',
     ];
+
+    /**
+     * @return bool
+     */
+    public function isAdmin()
+    {
+        return ($this->role ?? self::BASIC_ROLE) == self::ADMIN_ROLE;
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -63,6 +63,6 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
      */
     public function isAdmin()
     {
-        return ($this->role ?? self::BASIC_ROLE) == self::ADMIN_ROLE;
+        return (isset($this->role) ? $this->role : self::BASIC_ROLE) == self::ADMIN_ROLE;
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -15,7 +15,8 @@ class UserPolicy
      */
     public function before(User $currentUser)
     {
-        if ($currentUser->tokenCan('admin')) {
+        //Add tokenCan without * scope. To be sure that basic scope is passed. Now check if * scope is passed with undefined scope
+        if ($currentUser->isAdmin() && (!$currentUser->tokenCan('basic') || $currentUser->tokenCan('undefined'))) {
             return true;
         }
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -41,6 +41,12 @@ class AuthServiceProvider extends ServiceProvider
         Passport::tokensCan([
             'admin' => 'Admin user scope',
             'basic' => 'Basic user scope',
+            'users' => 'Users scope',
+            'users:list' => 'Users scope',
+            'users:read' => 'Users scope for reading records',
+            'users:write' => 'Users scope for writing records',
+            'users:create' => 'Users scope for creating records',
+            'users:delete' => 'Users scope for deleting records',
         ]);
 
         //Register all policies here

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -74,7 +74,9 @@ $app->configure('database');
 
  $app->routeMiddleware([
      'auth' => App\Http\Middleware\Authenticate::class,
-     'throttle' => App\Http\Middleware\ThrottleRequests::class
+     'throttle' => App\Http\Middleware\ThrottleRequests::class,
+     'scopes'   => \Laravel\Passport\Http\Middleware\CheckScopes::class,
+     'scope'    => \Laravel\Passport\Http\Middleware\CheckForAnyScope::class
  ]);
 
 /*

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,10 +24,25 @@ $app->get('appKey', function () {
 $app->post('accessToken', 'AccessTokenController@createAccessToken');
 
 $app->group(['middleware' => ['auth:api', 'throttle:60']], function () use ($app) {
-    $app->post('users', 'UserController@store');
-    $app->get('users', 'UserController@index');
-    $app->get('users/{id}', 'UserController@show');
-    $app->put('users/{id}', 'UserController@update');
-    $app->delete('users/{id}', 'UserController@destroy');
+    $app->post('users', [
+        'uses'       => 'UserController@store',
+        'middleware' => "scope:users,users:create"
+    ]);
+    $app->get('users',  [
+        'uses'       => 'UserController@index',
+        'middleware' => "scope:users,users:list"
+    ]);
+    $app->get('users/{id}', [
+        'uses'       => 'UserController@show',
+        'middleware' => "scope:users,users:read"
+    ]);
+    $app->put('users/{id}', [
+        'uses'       => 'UserController@update',
+        'middleware' => "scope:users,users:write"
+    ]);
+    $app->delete('users/{id}', [
+        'uses'       => 'UserController@destroy',
+        'middleware' => "scope:users,users:delete"
+    ]);
 });
 

--- a/tests/Endpoints/UsersTest.php
+++ b/tests/Endpoints/UsersTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Endpoints;
 use App\Models\User;
 use Laravel\Lumen\Testing\DatabaseMigrations;
+use Laravel\Passport\Token;
 
 
 class UsersTest extends \TestCase
@@ -16,6 +17,7 @@ class UsersTest extends \TestCase
         $this->assertResponseStatus(401);
 
         $user = factory(User::class)->create();
+        $user->withAccessToken(new Token(['scopes' => ['*']]));
         $this->actingAs($user);
 
         $this->call('GET', '/users');
@@ -35,6 +37,7 @@ class UsersTest extends \TestCase
         $user = factory(User::class)->create();
 
         // authenticate
+        $user->withAccessToken(new Token(['scopes' => ['*']]));
         $this->actingAs($user);
 
         // should work
@@ -56,6 +59,7 @@ class UsersTest extends \TestCase
         $this->assertResponseStatus(401);
 
         $user = factory(User::class)->make();
+        $user->withAccessToken(new Token(['scopes' => ['*']]));
         $this->actingAs($user);
 
         // empty data should give 400 invalid fields error
@@ -88,6 +92,7 @@ class UsersTest extends \TestCase
         $this->assertResponseStatus(401);
 
         // authenticate
+        $user->withAccessToken(new Token(['scopes' => ['*']]));
         $this->actingAs($user);
 
         $this->call('PUT', '/users/'.$user->uid, [
@@ -111,6 +116,7 @@ class UsersTest extends \TestCase
         $user = factory(User::class)->create();
 
         // authenticate
+        $user->withAccessToken(new Token(['scopes' => ['*']]));
         $this->actingAs($user);
 
         // should work

--- a/tests/Http/Middleware/ThrottleRequestsTest.php
+++ b/tests/Http/Middleware/ThrottleRequestsTest.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\ThrottleRequests;
 use App\Models\User;
 use Illuminate\Http\Request;
 use Laravel\Lumen\Testing\DatabaseMigrations;
+use Laravel\Passport\Token;
 
 
 class ThrottleRequestsTest extends \TestCase
@@ -49,6 +50,7 @@ class ThrottleRequestsTest extends \TestCase
         $user = factory(User::class)->create();
 
         // authenticate
+        $user->withAccessToken(new Token(['scopes' => ['*']]));
         $this->actingAs($user);
 
         for ($i = 1; $i <= 65 ; $i++) {


### PR DESCRIPTION
Based on my issue for scopes #31 this is my pull request. 
You have basic 'users' scope for all user related stuff. And users:create, users:read..etc. if you want specific scope for a token. For Administrator there is no logic to have 'admin' scope, so if you pass and 'basic' scope to an administrator he will have the same permissions as a nomer users and he will be able to control only his objects. 
I also updated the Readme file for message entity. If you find any problem please let me know or if you don't agree with my proposal. 
