### PR TITLE
Upgrade to lumen 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Homestead.yaml
 /vendor/
 /.idea/
 /storage/*.key
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ language: php
 services:
  - mysql
 php:
+  - 7.2
   - 7.1
-  - 5.6
+  - 7.0
+  - hhvm
 
 before_script:
   - cp .env.travis .env

--- a/app/Http/Controllers/AccessTokenController.php
+++ b/app/Http/Controllers/AccessTokenController.php
@@ -39,11 +39,6 @@ class AccessTokenController extends Controller
     {
         $inputs = $request->all();
 
-        $user = null;
-        if (isset($inputs['username']) && $inputs['grant_type'] == 'password') {
-            $user = $this->userRepository->findOneBy(['email' => $inputs['username']]);
-        }
-
         //Set default scope with full access
         if (!isset($inputs['scope']) || empty($inputs['scope'])) {
             $inputs['scope'] = "*";

--- a/artisan
+++ b/artisan
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Output\ConsoleOutput;
 |
 */
 
-$app = require __DIR__.'/bootstrap/app.php';
+$router = require __DIR__.'/bootstrap/app.php';
 
 /*
 |--------------------------------------------------------------------------
@@ -28,7 +28,7 @@ $app = require __DIR__.'/bootstrap/app.php';
 |
 */
 
-$kernel = $app->make(
+$kernel = $router->make(
     'Illuminate\Contracts\Console\Kernel'
 );
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,7 @@
 <?php
 
+use Dusterio\LumenPassport\LumenPassport;
+
 require_once __DIR__.'/../vendor/autoload.php';
 
 try {
@@ -96,8 +98,10 @@ $app->register(App\Providers\EventServiceProvider::class);
 $app->register(App\Providers\RepositoriesServiceProvider::class);
 $app->register(Laravel\Passport\PassportServiceProvider::class);
 $app->register(Dusterio\LumenPassport\PassportServiceProvider::class);
-$app->register(Barryvdh\Cors\LumenServiceProvider::class);
+$app->register(Barryvdh\Cors\ServiceProvider::class);
 $app->register(\Illuminate\Mail\MailServiceProvider::class);
+
+LumenPassport::routes($app);
 
 /*
 |--------------------------------------------------------------------------
@@ -110,7 +114,9 @@ $app->register(\Illuminate\Mail\MailServiceProvider::class);
 |
 */
 
-$app->group(['namespace' => 'App\Http\Controllers'], function ($app) {
+$app->router->group([
+    'namespace' => 'App\Http\Controllers'
+], function ($router) {
     require __DIR__.'/../routes/web.php';
 });
 

--- a/composer.json
+++ b/composer.json
@@ -5,19 +5,19 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": ">=5.6.4",
-        "laravel/lumen-framework": "5.4.*",
-        "vlucas/phpdotenv": "~2.2",
-        "ramsey/uuid": "^3.5",
-        "league/fractal": "^0.15.0",
-        "dusterio/lumen-passport": "^0.1.9",
-        "barryvdh/laravel-cors": "^0.8.6",
-        "illuminate/mail": "^5.4"
+        "php": ">=7.0.0",
+        "laravel/lumen-framework": "5.5.*",
+        "vlucas/phpdotenv": "~2.4",
+        "ramsey/uuid": "^3.7",
+        "league/fractal": "^0.17.0",
+        "dusterio/lumen-passport": "^0.2.4",
+        "barryvdh/laravel-cors": "^0.11.0",
+        "illuminate/mail": "5.5.*"
     },
     "require-dev": {
-        "fzaninotto/faker": "~1.4",
-        "phpunit/phpunit": "~5.0",
-        "mockery/mockery": "~0.9"
+        "fzaninotto/faker": "~1.7",
+        "phpunit/phpunit": "~6.5",
+        "mockery/mockery": "~1.0"
     },
     "autoload": {
         "psr-4": {

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 
-# REST API with Lumen 5.4 [![Build Status](https://travis-ci.org/hasib32/rest-api-with-lumen.svg?branch=master)](https://travis-ci.org/hasib32/rest-api-with-lumen)
+# REST API with Lumen 5.5 [![Build Status](https://travis-ci.org/hasib32/rest-api-with-lumen.svg?branch=master)](https://travis-ci.org/hasib32/rest-api-with-lumen)
 
 A RESTful API boilerplate for Lumen micro-framework. Features included:
 
@@ -25,7 +25,7 @@ $ git clone git@github.com:hasib32/rest-api-with-lumen.git
 ```
 
 #### Laravel Homestead
-You can use Laravel Homestead globally or per project for local development. Follow the [Installation Guide](https://laravel.com/docs/5.4/homestead#installation-and-setup).
+You can use Laravel Homestead globally or per project for local development. Follow the [Installation Guide](https://laravel.com/docs/5.5/homestead#installation-and-setup).
 
 #### Install dependencies
 ```
@@ -97,29 +97,29 @@ Creating a new resource is very easy and straight-forward. Follow these simple s
 Create a new route name ```messages```. Open the ```routes/web.php``` file and add the following code:
 
 ```php
-$app->post('messages', [
+$route->post('messages', [
     'uses'       => 'MessageController@store',
     'middleware' => "scope:messages,messages:create"
 ]);
-$app->get('messages',  [
+$route->get('messages',  [
     'uses'       => 'MessageController@index',
     'middleware' => "scope:messages,messages:list"
 ]);
-$app->get('messages/{id}', [
+$route->get('messages/{id}', [
     'uses'       => 'MessageController@show',
     'middleware' => "scope:messages,messages:read"
 ]);
-$app->put('messages/{id}', [
+$route->put('messages/{id}', [
     'uses'       => 'MessageController@update',
     'middleware' => "scope:messages,messages:write"
 ]);
-$app->delete('messages/{id}', [
+$route->delete('messages/{id}', [
     'uses'       => 'MessageController@destroy',
     'middleware' => "scope:messages,messages:delete"
 ]);
 ```
 
-For more info please visit Lumen [Routing](https://lumen.laravel.com/docs/5.4/routing) page.
+For more info please visit Lumen [Routing](https://lumen.laravel.com/docs/5.5/routing) page.
 
 ### Step 2: Create Model and Migration for the Table
 Create ```Message``` Model inside ```App/Models``` directory and create migration using Lumen Artisan command.
@@ -156,7 +156,7 @@ class Message extends Model
 }
 ```
 
-Visit Laravel [Eloquent](https://laravel.com/docs/5.4/eloquent) Page for more info about Model.
+Visit Laravel [Eloquent](https://laravel.com/docs/5.5/eloquent) Page for more info about Model.
 
 **Create migration for messages table**
 
@@ -187,7 +187,7 @@ class CreateMessagesTable extends Migration
 }
 ```
 
-For more info visit Laravel [Migration](https://laravel.com/docs/5.4/migrations) page.
+For more info visit Laravel [Migration](https://laravel.com/docs/5.5/migrations) page.
 
 ### Step 3: Create Repository
 Create ```MessageRepository``` and implementation of the repository name ```EloquentMessageRepository```.
@@ -277,7 +277,7 @@ class RepositoriesServiceProvider extends ServiceProvider
 }
 ```
 
-Visit Lumen documentation for more info about [Service Provider](https://lumen.laravel.com/docs/5.4/providers).
+Visit Lumen documentation for more info about [Service Provider](https://lumen.laravel.com/docs/5.5/providers).
 
 ### Step 4: Create Fractal Transformer
 Fractal provides a presentation and transformation layer for complex data output, the like found in RESTful APIs, and works really well with JSON. Think of this as a view layer for your JSON/YAML/etc.
@@ -389,7 +389,7 @@ And add scopes to ``Passport::tokensCan``:
     'messages:delete' => 'Messages scope for deleting records'
 ]
 ```
-Visit Lumen [Authorization Page](https://lumen.laravel.com/docs/5.4/authorization) for more info about Policy.
+Visit Lumen [Authorization Page](https://lumen.laravel.com/docs/5.5/authorization) for more info about Policy.
 
 ### Last Step: Create Controller
  
@@ -578,7 +578,7 @@ class MessageController extends Controller
 }
 ```
 
-Visit Lumen [Controller](https://lumen.laravel.com/docs/5.4/controllers) page for more info about Controller.
+Visit Lumen [Controller](https://lumen.laravel.com/docs/5.5/controllers) page for more info about Controller.
 
 ## Tutorial
 To see the step-by-step tutorial how I created this boilerplate please visit our blog [devnootes.net](https://devnotes.net/rest-api-development-with-lumen-part-one/).

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,4 +1,5 @@
 <?php
+use Laravel\Lumen\Routing\Router;
 
 /*
 |--------------------------------------------------------------------------
@@ -10,37 +11,37 @@
 | and give it the Closure to call when that URI is requested.
 |
 */
-
-$app->get('/', function () use ($app) {
-    return $app->version();
+/** @var \Laravel\Lumen\Routing\Router $router */
+$router->get('/', function () {
+    return app()->version();
 });
 
 // Generate random string
-$app->get('appKey', function () {
+$router->get('appKey', function () {
     return str_random('32');
 });
 
 // route for creating access_token
-$app->post('accessToken', 'AccessTokenController@createAccessToken');
+$router->post('accessToken', 'AccessTokenController@createAccessToken');
 
-$app->group(['middleware' => ['auth:api', 'throttle:60']], function () use ($app) {
-    $app->post('users', [
+$router->group(['middleware' => ['auth:api', 'throttle:60']], function () use ($router) {
+    $router->post('users', [
         'uses'       => 'UserController@store',
         'middleware' => "scope:users,users:create"
     ]);
-    $app->get('users',  [
+    $router->get('users',  [
         'uses'       => 'UserController@index',
         'middleware' => "scope:users,users:list"
     ]);
-    $app->get('users/{id}', [
+    $router->get('users/{id}', [
         'uses'       => 'UserController@show',
         'middleware' => "scope:users,users:read"
     ]);
-    $app->put('users/{id}', [
+    $router->put('users/{id}', [
         'uses'       => 'UserController@update',
         'middleware' => "scope:users,users:write"
     ]);
-    $app->delete('users/{id}', [
+    $router->delete('users/{id}', [
         'uses'       => 'UserController@destroy',
         'middleware' => "scope:users,users:delete"
     ]);


### PR DESCRIPTION
Upgrade to Lumen 5.5
- php requires 7+ now
- update composer packages and requirements to the latest available
- support Laravel 5.5 changes - router,  LumenPassport
- Remove unneeded code for $user
- update Travis builds for latest php versions

For issue: #40 

Maybe you can create a new branch for old 5.4 and a tag it. So changes for 5.5 are on master and development